### PR TITLE
frontend files are serve with static

### DIFF
--- a/client-frontend/docker-entrypoint.sh
+++ b/client-frontend/docker-entrypoint.sh
@@ -5,7 +5,7 @@ cd /openspending-frontend
 git pull origin develop
 
 yarn install
-yarn generate
+yarn generate --fail-on-error
 
 rm -rf /static/client-frontend
 mkdir -p /static/client-frontend

--- a/client-frontend/docker-entrypoint.sh
+++ b/client-frontend/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 cd /openspending-frontend
 git pull origin develop
 
+cd /client-frontend
 yarn install
 yarn generate --fail-on-error
 

--- a/client-frontend/docker-entrypoint.sh
+++ b/client-frontend/docker-entrypoint.sh
@@ -1,8 +1,12 @@
-#!/bin/bash
-set -eu
-
-cd /openspending-frontend && git pull origin develop
+#!/bin/sh
+set -e
 
 cd /openspending-frontend
+git pull origin develop
+
 yarn install
-yarn dev
+yarn generate
+
+rm -rf /static/client-frontend
+mkdir -p /static/client-frontend
+cp -a ./dist/* /static/client-frontend

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,14 +2,6 @@ upstream server-backend-host {
     server server-backend:8000;
 }
 
-upstream server-frontend-host {
-    server server-frontend:3000;
-}
-
-upstream client-frontend-host {
-    server client-frontend:3000;
-}
-
 server {
     listen 80 default_server;
     
@@ -25,10 +17,7 @@ server {
     }
 
     location / {
-        proxy_pass http://client-frontend-host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_redirect off;
+        alias /static/client-frontend/;
     }
 }
 
@@ -37,9 +26,6 @@ server {
     server_name admin.openspending.net;
 
     location / {
-        proxy_pass http://server-frontend-host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $host;
-        proxy_redirect off;
+        alias /static/server-frontend/;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,12 @@ services:
       - server-backend
   client-frontend:
     build: ./client-frontend
-    restart: always
     volumes:
       - static_volume:/static
     depends_on:
       - server-backend
   server-frontend:
     build: ./server-frontend
-    restart: always
     volumes:
       - static_volume:/static
     depends_on:

--- a/server-backend/docker-entrypoint.sh
+++ b/server-backend/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 cd /openspending-backend
 git pull origin develop
 
-cd backend
+cd /server-backend
 python manage.py makemigrations
 python manage.py makemigrations budgetmapper
 python manage.py migrate

--- a/server-backend/docker-entrypoint.sh
+++ b/server-backend/docker-entrypoint.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
-set -eu
+#!/bin/sh
+set -e
 
-cd /openspending-backend && git pull origin develop
+cd /openspending-backend
+git pull origin develop
 
-cd /server-backend
+cd backend
 python manage.py makemigrations
 python manage.py makemigrations budgetmapper
 python manage.py migrate

--- a/server-frontend/Dockerfile
+++ b/server-frontend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:16
 RUN cd / && git clone https://github.com/spendingjp/openspending-backend.git 
 RUN ln -s /openspending-backend/frontend /server-frontend
 
-RUN cd /openspending-backend/frontend && yarn install
+RUN cd /server-frontend && yarn install
 
 COPY ./docker-entrypoint.sh /
 EXPOSE 3000

--- a/server-frontend/docker-entrypoint.sh
+++ b/server-frontend/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 cd /openspending-backend
 git pull origin develop
 
-cd frontend
+cd /server-frontend
 yarn install
 yarn generate --fail-on-error
 

--- a/server-frontend/docker-entrypoint.sh
+++ b/server-frontend/docker-entrypoint.sh
@@ -1,8 +1,13 @@
-#!/bin/bash
-set -eu
+#!/bin/sh
+set -e
 
-cd /openspending-backend && git pull origin develop
+cd /openspending-backend
+git pull origin develop
 
-cd /openspending-backend/frontend
+cd frontend
 yarn install
-yarn dev
+yarn generate
+
+rm -rf /static/server-frontend
+mkdir -p /static/server-frontend
+cp -a ./dist/* /static/server-frontend

--- a/server-frontend/docker-entrypoint.sh
+++ b/server-frontend/docker-entrypoint.sh
@@ -6,7 +6,7 @@ git pull origin develop
 
 cd frontend
 yarn install
-yarn generate
+yarn generate --fail-on-error
 
 rm -rf /static/server-frontend
 mkdir -p /static/server-frontend


### PR DESCRIPTION
`yarn dev` で起動したサーバを upstream として配信する動作から `yarn generate` したあとのファイルを Nginx で静的に配信する動作に変更

frontend の yarn generate に失敗すると、失敗した結果かが配信されるためサービスの異常に気づきにくい気があり